### PR TITLE
Close swarm-connections when ws-connection ends

### DIFF
--- a/lib/node-proxy.js
+++ b/lib/node-proxy.js
@@ -80,6 +80,10 @@ function onStreamClose () {
     .off('close', this._onClose)
     .off('signature', this._onSignature)
     .off('noiseReply', this._onNoiseReply)
+
+  for (const connection of this._connections.values()) {
+    connection.destroy()
+  }
 }
 
 function onConnect (message) {


### PR DESCRIPTION
Currently, when a connection closes, the `NodeProxy` object does not close the swarm-connections it has established, so I think they remain open indefinitely until either the dht-relay shuts down or the other peers disconnect