### PR TITLE
Fix the relayer crashing on peer disconnect

### DIFF
--- a/lib/server-proxy.js
+++ b/lib/server-proxy.js
@@ -89,7 +89,7 @@ function onServerConnection (stream) {
   this._node._connecting.set(alias, stream)
 
   const onError = (err) => {
-    this._protocol.destroy.send({ alias, error: err.message })
+    this._protocol.destroy.send({ paired: true, alias, error: err.message });
   }
 
   const onClose = () => {


### PR DESCRIPTION
The relayer randomly crashes on peer disconnect with the error:

```error
@hyperswarm\dht-relay\node_modules\compact-encoding\index.js:1007
throw new Error('uint must be positive')
^

Error: uint must be positive
at validateUint (...\node_modules@hyperswarm\dht-relay\node_modules\compact-encoding\index.js:1007:11)
at Object.encode (...\node_modules@hyperswarm\dht-relay\node_modules\compact-encoding\index.js:91:5)
at Object.encode (...\node_modules@hyperswarm\dht-relay\lib\messages.js:193:10)
.
.
.
```

This only happens when the connection is fully paired, so adding this prevents the encoder from throwing